### PR TITLE
Changed 'Auto update project wiki' to run on 'main' branch

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -3,7 +3,7 @@ name: Auto update project wiki
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - 'v*' # Initializes on any new tag
 


### PR DESCRIPTION
It seems after changing main branch from 'master' to 'main' old branch was used still in 'Auto update project wiki' action. This will fix that.